### PR TITLE
ft: Calculate height from bounding box

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -19,11 +19,12 @@ tasks:
   - test: |
       cd crossfont
       cargo test
+  - oldstable: |
+      cd crossfont
+      rustup toolchain install --profile minimal 1.43.1
+      rustup default 1.43.1
+      cargo test
   - clippy: |
       cd crossfont
       rustup component add clippy
       cargo clippy --all-targets
-  - oldstable: |
-      cd crossfont
-      rustup toolchain install --profile minimal 1.43.1
-      cargo +1.43.1 test

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -23,11 +23,12 @@ tasks:
       cd crossfont
       rustup toolchain install nightly -c rustfmt
       cargo +nightly fmt -- --check
+  - oldstable: |
+      cd crossfont
+      rustup toolchain install --profile minimal 1.43.1
+      rustup default 1.43.1
+      cargo test
   - clippy: |
       cd crossfont
       rustup component add clippy
       cargo clippy --all-targets
-  - oldstable: |
-      cd crossfont
-      rustup toolchain install --profile minimal 1.43.1
-      cargo +1.43.1 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Stable
         run: cargo test
-      - name: Clippy
-        run: |
-          rustup component add clippy
-          cargo clippy --all-targets
       - name: Oldstable
         run: |
           rustup default 1.43.1
           cargo test
+      - name: Clippy
+        run: |
+          rustup component add clippy
+          cargo clippy --all-targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- FreeType font height metric will now use `(ascent - descent)` if it is bigger than height
+
 ## 0.2.0
 
 ### Changed

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -416,7 +416,7 @@ impl Font {
                 height: 0,
                 top: 0,
                 left: 0,
-                buffer: BitmapBuffer::RGB(Vec::new()),
+                buffer: BitmapBuffer::Rgb(Vec::new()),
             };
         }
 
@@ -470,9 +470,9 @@ impl Font {
         let rasterized_pixels = cg_context.data().to_vec();
 
         let buffer = if is_colored {
-            BitmapBuffer::RGBA(byte_order::extract_rgba(&rasterized_pixels))
+            BitmapBuffer::Rgba(byte_order::extract_rgba(&rasterized_pixels))
         } else {
-            BitmapBuffer::RGB(byte_order::extract_rgb(&rasterized_pixels))
+            BitmapBuffer::Rgb(byte_order::extract_rgb(&rasterized_pixels))
         };
 
         RasterizedGlyph {
@@ -542,7 +542,7 @@ mod tests {
                 let glyph = font.get_glyph(*character, glyph_index, false);
 
                 let buffer = match &glyph.buffer {
-                    BitmapBuffer::RGB(buffer) | BitmapBuffer::RGBA(buffer) => buffer,
+                    BitmapBuffer::Rgb(buffer) | BitmapBuffer::Rgba(buffer) => buffer,
                 };
 
                 // Debug the glyph.. sigh.

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -80,7 +80,7 @@ impl DirectWriteRasterizer {
         let bounds =
             glyph_analysis.get_alpha_texture_bounds(dwrote::DWRITE_TEXTURE_CLEARTYPE_3x1)?;
 
-        let buffer = BitmapBuffer::RGB(
+        let buffer = BitmapBuffer::Rgb(
             glyph_analysis.create_alpha_texture(dwrote::DWRITE_TEXTURE_CLEARTYPE_3x1, bounds)?,
         );
 

--- a/src/ft/fc/char_set.rs
+++ b/src/ft/fc/char_set.rs
@@ -55,16 +55,11 @@ impl CharSetRef {
         }
     }
 
-    pub fn merge(&self, other: &CharSetRef) -> Result<bool, ()> {
+    pub fn merge(&self, other: &CharSetRef) {
         unsafe {
             // Value is just an indicator whether something was added or not.
             let mut value: FcBool = 0;
-            let res = FcCharSetMerge(self.as_ptr() as _, other.as_ptr() as _, &mut value);
-            if res == 0 {
-                Err(())
-            } else {
-                Ok(value != 0)
-            }
+            FcCharSetMerge(self.as_ptr() as _, other.as_ptr() as _, &mut value);
         }
     }
 }

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -27,7 +27,7 @@ pub mod char_set;
 pub use char_set::{CharSet, CharSetRef};
 
 pub mod pattern;
-pub use pattern::{FTFaceLocation, Pattern, PatternHash, PatternRef};
+pub use pattern::{FtFaceLocation, Pattern, PatternHash, PatternRef};
 
 /// Find the font closest matching the provided pattern.
 ///

--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -103,7 +103,7 @@ impl<'a> IntPropertyIter<'a> {
     }
 
     fn get_value(&self, index: usize) -> Option<isize> {
-        let mut value = 0 as c_int;
+        let mut value: c_int = 0;
 
         let result = unsafe {
             FcPatternGetInteger(
@@ -348,12 +348,12 @@ macro_rules! string_accessor {
 pub struct PatternHash(pub u32);
 
 #[derive(Hash, Eq, PartialEq, Debug)]
-pub struct FTFaceLocation {
+pub struct FtFaceLocation {
     pub path: PathBuf,
     pub index: isize,
 }
 
-impl FTFaceLocation {
+impl FtFaceLocation {
     pub fn new(path: PathBuf, index: isize) -> Self {
         Self { path, index }
     }
@@ -606,9 +606,9 @@ impl PatternRef {
         unsafe { self.get_string(b"file\0").nth(index) }.map(From::from)
     }
 
-    pub fn ft_face_location(&self, index: usize) -> Option<FTFaceLocation> {
+    pub fn ft_face_location(&self, index: usize) -> Option<FtFaceLocation> {
         match (self.file(index), self.index().next()) {
-            (Some(path), Some(index)) => Some(FTFaceLocation::new(path, index)),
+            (Some(path), Some(index)) => Some(FtFaceLocation::new(path, index)),
             _ => None,
         }
     }

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -122,8 +122,11 @@ impl Rasterize for FreeTypeRasterizer {
         let face = &mut self.faces.get(&key).ok_or(Error::UnknownFontKey)?;
         let full = self.full_metrics(&face)?;
 
-        let height = (full.size_metrics.height / 64) as f64;
+        let ascent = (full.size_metrics.ascender / 64) as f32;
         let descent = (full.size_metrics.descender / 64) as f32;
+        let glyph_height = (full.size_metrics.height / 64) as f64;
+        let global_glyph_height = (ascent - descent) as f64;
+        let height = f64::max(glyph_height, global_glyph_height);
 
         // Get underline position and thickness in device pixels.
         let x_scale = full.size_metrics.x_scale as f32 / 65536.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,10 @@ pub struct RasterizedGlyph {
 #[derive(Clone, Debug)]
 pub enum BitmapBuffer {
     /// RGB alphamask.
-    RGB(Vec<u8>),
+    Rgb(Vec<u8>),
 
     /// RGBA pixels with premultiplied alpha.
-    RGBA(Vec<u8>),
+    Rgba(Vec<u8>),
 }
 
 impl Default for RasterizedGlyph {
@@ -174,7 +174,7 @@ impl Default for RasterizedGlyph {
             height: 0,
             top: 0,
             left: 0,
-            buffer: BitmapBuffer::RGB(Vec::new()),
+            buffer: BitmapBuffer::Rgb(Vec::new()),
         }
     }
 }


### PR DESCRIPTION
In alacritty/alacritty#2693, we see two problems: powerline separator glyphs are offset both vertically and horizontally.  Having meticulously redesigned the powerline separator glyphs for Hack in source-foundry/Hack#234, I can say with some degree of confidence that the horizontal misalignment is due to the separator glyphs not being designed to be larger than the bounding box.  That is to say, it's a font problem.

The vertical misaligment, however, comes down to how this library is calculating the font height.  FreeType provides a height metric, but it represents ["the vertical distance between two consecutive baselines"](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_facerec) which doesn't necessarily correspond to the height of the glyphs.  Thus we get a situation where glyphs appear slightly above and below than the line on which their drawn.  You might want that for typesetting proportional fonts, but it doesn't make much sense in a monospace, terminal-like application.

For calculating the global glyph height, the FreeType documentation says to use the difference between the ascender and descender metrics.  Indeed, that is what [urxvt](https://github.com/exg/rxvt-unicode/blob/rxvt-unicode-rel-9.22/src/rxvtfont.C#L1244) and [xterm](https://github.com/Maximus5/xterm/blob/73ac00b39ec6f4af3b43908996a4bc73410a47df/src/fontutils.c#L833) do, and that is what is implemented in this patch.

This change may cause alacritty to render a pixel or two more space between lines depending on the font.  The spacing can be tweaked with the `font.offset` setting at the expense of powerline separator seamlessness.

![alacritty-before-and-after-ft-height-change](https://user-images.githubusercontent.com/646230/90344094-63e96880-dfe4-11ea-9270-2475cc703d3a.png)
