### PR TITLE
Fix compilation with FreeType version below 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minimum Rust version has been bumped to 1.43.0
+
+### Fixed
+
+- Compilation with FreeType version below 2.8.0 on Linux/BSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ log = "0.4"
 servo-fontconfig = "0.5.1"
 freetype-rs = "0.26"
 
+[target.'cfg(not(any(target_os = "macos", windows)))'.build-dependencies]
+pkg-config = "0.3"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.20.1"
 core-foundation = "0.7"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // This libtool version maps to FreeType version 2.8.0, so we can use
+    // `FT_Set_Default_Properties`.
+    #[cfg(not(any(target_os = "macos", windows)))]
+    if pkg_config::Config::new().atleast_version("20.0.14").probe("freetype2").is_ok() {
+        println!("cargo:rustc-cfg=ft_set_default_properties_available")
+    }
+}

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -101,6 +101,7 @@ impl Rasterize for FreeTypeRasterizer {
     fn new(device_pixel_ratio: f32, _: bool) -> Result<FreeTypeRasterizer, Error> {
         let library = Library::init()?;
 
+        #[cfg(ft_set_default_properties_available)]
         unsafe {
             // Initialize default properties, like user preferred interpreter.
             freetype_sys::FT_Set_Default_Properties(library.raw());


### PR DESCRIPTION
This should allow building on systems without recent FreeType
by excluding calls to recent FreeType features.