### PR TITLE
Return missing glyph as Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rasterizer no longer uses associated platform-specific error type and now has common type for `Error`
-- If the glyph you've requested is missing, the resulting missing glyph char will be in `Error::MissingGlyph`
+- The rasterizer's `Error` type is now shared across platforms
+- Missing glyphs are now returned as the content of the `MissingGlyph` error
 - `RasterizedGlyph`'s `c` and `buf` fields are now named `character` and `buffer` respectively
 - `GlyphKey`'s `c` field is now named `character`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Rasterizer no longer uses associated `Err` type and now has common type for `Error`
+- If the glyph you've requested is missing, the resulted missing glyph char will be in `Error::MissingGlyph`
+
 ## 0.1.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rasterizer no longer uses associated `Err` type and now has common type for `Error`
-- If the glyph you've requested is missing, the resulted missing glyph char will be in `Error::MissingGlyph`
+- Rasterizer no longer uses associated platform-specific error type and now has common type for `Error`
+- If the glyph you've requested is missing, the resulting missing glyph char will be in `Error::MissingGlyph`
+- `RasterizedGlyph`'s `c` and `buf` fields are now named `character` and `buffer` respectively
+- `GlyphKey`'s `c` field is now named `character`
 
 ## 0.1.1
 

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -117,7 +117,7 @@ impl crate::Rasterize for Rasterizer {
         // Get loaded font.
         let font = self.fonts.get(&glyph.font_key).ok_or(Error::UnknownFontKey)?;
 
-        // Find a font where the given char is present.
+        // Find a font where the given character is present.
         let (font, glyph_index) = iter::once(font)
             .chain(font.fallbacks.iter())
             .find_map(|font| match font.glyph_index(glyph.character) {

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -168,7 +168,7 @@ impl crate::Rasterize for DirectWriteRasterizer {
         let glyph_index = self.get_glyph_index(face, character);
 
         let glyph_metrics = face.get_design_glyph_metrics(&[glyph_index], false);
-        let hmetrics = glyph_metrics.first().ok_or(Error::MetricsNotFont)?;
+        let hmetrics = glyph_metrics.first().ok_or(Error::MetricsNotFound)?;
 
         let average_advance = f64::from(hmetrics.advanceWidth) * f64::from(scale);
 

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::fmt::{self, Display, Formatter};
 use std::os::windows::ffi::OsStringExt;
 
 use dwrote::{
@@ -16,7 +15,8 @@ use winapi::um::dwrite;
 use winapi::um::winnls::GetUserDefaultLocaleName;
 
 use super::{
-    BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style, Weight,
+    BitmapBuffer, Error, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style,
+    Weight,
 };
 
 /// Cached DirectWrite font.
@@ -41,10 +41,9 @@ impl DirectWriteRasterizer {
         &self,
         face: &FontFace,
         size: Size,
-        c: char,
+        character: char,
+        glyph_index: u16,
     ) -> Result<RasterizedGlyph, Error> {
-        let glyph_index = self.get_glyph_index(face, c)?;
-
         let em_size = em_size(size);
 
         let glyph_run = DWRITE_GLYPH_RUN {
@@ -73,18 +72,18 @@ impl DirectWriteRasterizer {
             0.0,
             0.0,
         )
-        .map_err(Error::DirectWriteError)?;
+        .map_err(Error::from)?;
 
         let bounds = glyph_analysis
             .get_alpha_texture_bounds(dwrote::DWRITE_TEXTURE_CLEARTYPE_3x1)
-            .map_err(Error::DirectWriteError)?;
+            .map_err(Error::from)?;
 
         let buf = glyph_analysis
             .create_alpha_texture(dwrote::DWRITE_TEXTURE_CLEARTYPE_3x1, bounds)
-            .map_err(Error::DirectWriteError)?;
+            .map_err(Error::from)?;
 
         Ok(RasterizedGlyph {
-            c,
+            c: character,
             width: (bounds.right - bounds.left) as i32,
             height: (bounds.bottom - bounds.top) as i32,
             top: -bounds.top,
@@ -97,15 +96,12 @@ impl DirectWriteRasterizer {
         self.fonts.get(&font_key).ok_or(Error::FontNotLoaded)
     }
 
-    fn get_glyph_index(&self, face: &FontFace, c: char) -> Result<u16, Error> {
-        let idx = *face
-            .get_glyph_indices(&[c as u32])
-            .first()
+    fn get_glyph_index(&self, face: &FontFace, c: char) -> Option<u16> {
+        match *face.get_glyph_indices(&[c as u32]).first()? {
             // DirectWrite returns 0 if the glyph does not exist in the font.
-            .filter(|glyph_index| **glyph_index != 0)
-            .ok_or_else(|| Error::MissingGlyph(c))?;
-
-        Ok(idx)
+            0 => None,
+            glyph_index => Some(glyph_index),
+        }
     }
 
     fn get_fallback_font(&self, loaded_font: &Font, c: char) -> Option<dwrote::Font> {
@@ -141,8 +137,6 @@ impl DirectWriteRasterizer {
 }
 
 impl crate::Rasterize for DirectWriteRasterizer {
-    type Err = Error;
-
     fn new(device_pixel_ratio: f32, _: bool) -> Result<DirectWriteRasterizer, Error> {
         Ok(DirectWriteRasterizer {
             fonts: HashMap::new(),
@@ -172,11 +166,11 @@ impl crate::Rasterize for DirectWriteRasterizer {
         let line_height = f64::from(ascent - descent + line_gap);
 
         // Since all monospace characters have the same width, we use `!` for horizontal metrics.
-        let c = '!';
-        let glyph_index = self.get_glyph_index(face, c)?;
+        let character = '!';
+        let glyph_index = self.get_glyph_index(face, character).unwrap_or(0);
 
         let glyph_metrics = face.get_design_glyph_metrics(&[glyph_index], false);
-        let hmetrics = glyph_metrics.first().ok_or_else(|| Error::MissingGlyph(c))?;
+        let hmetrics = glyph_metrics.first().ok_or(Error::MissingSizeMetrics)?;
 
         let average_advance = f64::from(hmetrics.advanceWidth) * f64::from(scale);
 
@@ -238,40 +232,38 @@ impl crate::Rasterize for DirectWriteRasterizer {
     fn get_glyph(&mut self, glyph: GlyphKey) -> Result<RasterizedGlyph, Error> {
         let loaded_font = self.get_loaded_font(glyph.font_key)?;
 
-        match self.rasterize_glyph(&loaded_font.face, glyph.size, glyph.c) {
-            Err(err @ Error::MissingGlyph(_)) => {
-                let fallback_font = self.get_fallback_font(&loaded_font, glyph.c).ok_or(err)?;
-                self.rasterize_glyph(&fallback_font.create_font_face(), glyph.size, glyph.c)
+        let mut glyph_index = self.get_glyph_index(&loaded_font.face, glyph.c);
+        let fallback_font;
+
+        let font = match glyph_index {
+            Some(_) => loaded_font,
+            None => match self.get_fallback_font(&loaded_font, glyph.c) {
+                None => loaded_font,
+                Some(font) => {
+                    fallback_font = Font::from(font);
+                    glyph_index = self.get_glyph_index(&fallback_font.face, glyph.c);
+
+                    &fallback_font
+                },
             },
-            result => result,
+        };
+
+        // DirectWrite uses 0 for missing glyph symbols.
+        let is_missing_glyph = glyph_index.is_none();
+        let glyph_index = glyph_index.unwrap_or(0);
+
+        let rasterized_glyph =
+            self.rasterize_glyph(&font.face, glyph.size, glyph.c, glyph_index)?;
+
+        if is_missing_glyph {
+            Err(Error::MissingGlyph(rasterized_glyph))
+        } else {
+            Ok(rasterized_glyph)
         }
     }
 
     fn update_dpr(&mut self, device_pixel_ratio: f32) {
         self.device_pixel_ratio = device_pixel_ratio;
-    }
-}
-
-#[derive(Debug)]
-pub enum Error {
-    MissingFont(FontDesc),
-    MissingGlyph(char),
-    FontNotLoaded,
-    DirectWriteError(HRESULT),
-}
-
-impl std::error::Error for Error {}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Error::MissingGlyph(c) => write!(f, "Glyph not found for char {:?}", c),
-            Error::MissingFont(desc) => write!(f, "Unable to find the font {}", desc),
-            Error::FontNotLoaded => f.write_str("Tried to use a font that hasn't been loaded"),
-            Error::DirectWriteError(hresult) => {
-                write!(f, "A DirectWrite rendering error occurred: {:#X}", hresult)
-            },
-        }
     }
 }
 
@@ -331,5 +323,12 @@ impl TextAnalysisSourceMethods for TextAnalysisSourceData<'_> {
 
     fn get_paragraph_reading_direction(&self) -> dwrite::DWRITE_READING_DIRECTION {
         dwrite::DWRITE_READING_DIRECTION_LEFT_TO_RIGHT
+    }
+}
+
+impl From<HRESULT> for Error {
+    fn from(hresult: HRESULT) -> Self {
+        let message = format!("A DirectWrite rendering error occurred: {:#X}", hresult);
+        Error::PlatformError(message)
     }
 }

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -21,7 +21,7 @@ use super::{
     Slant, Style, Weight,
 };
 
-/// FreeType uses 0 for missing glyph
+/// FreeType uses 0 for the missing glyph:
 /// https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_get_char_index
 const MISSING_GLYPH_INDEX: u32 = 0;
 

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -409,7 +409,8 @@ impl FreeTypeRasterizer {
                     }
                 },
                 None => {
-                    if !font_pattern.get_charset().map_or(false, |cs| cs.has_char(glyph.character)) {
+                    if !font_pattern.get_charset().map_or(false, |cs| cs.has_char(glyph.character))
+                    {
                         continue;
                     }
 

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -289,7 +289,7 @@ impl FreeTypeRasterizer {
 
     fn full_metrics(&self, face_load_props: &FaceLoadingProperties) -> Result<FullMetrics, Error> {
         let ft_face = &face_load_props.ft_face;
-        let size_metrics = ft_face.size_metrics().ok_or(Error::MetricsNotFont)?;
+        let size_metrics = ft_face.size_metrics().ok_or(Error::MetricsNotFound)?;
 
         let width = match ft_face.load_char('0' as usize, face_load_props.load_flags) {
             Ok(_) => ft_face.glyph().metrics().horiAdvance / 64,
@@ -409,7 +409,7 @@ impl FreeTypeRasterizer {
                     }
                 },
                 None => {
-                    if font_pattern.get_charset().map_or(false, |cs| cs.has_char(glyph.character)) {
+                    if !font_pattern.get_charset().map_or(false, |cs| cs.has_char(glyph.character)) {
                         continue;
                     }
 
@@ -492,7 +492,7 @@ impl FreeTypeRasterizer {
                     Some(fixup_factor) => fixup_factor,
                     None => {
                         // Fallback if the user has bitmap scaling disabled.
-                        let metrics = face.ft_face.size_metrics().ok_or(Error::MetricsNotFont)?;
+                        let metrics = face.ft_face.size_metrics().ok_or(Error::MetricsNotFound)?;
                         f64::from(pixelsize) / f64::from(metrics.y_ppem)
                     },
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,8 @@ pub enum Error {
     /// Unable to find a font matching the description.
     FontNotFound(FontDesc),
 
-    /// Tried to get size metrics from a Face that didn't have a size.
-    MissingSizeMetrics,
+    /// Unable to find metrics information on a font face.
+    MetricsNotFont,
 
     /// The glyph could not be found in any font.
     MissingGlyph(RasterizedGlyph),
@@ -236,8 +236,8 @@ impl Display for Error {
                 write!(f, "glyph for character {:?} not found", glyph.character)
             },
             Error::UnknownFontKey => f.write_str("invalid font key"),
-            Error::MissingSizeMetrics => {
-                f.write_str("tried to get size metrics from a face without a size")
+            Error::MetricsNotFont => {
+                f.write_str("unable to find metrics information on a font face")
             },
             Error::PlatformError(err) => write!(f, "{}", err),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub enum Error {
     /// Unable to find a font matching the description.
     FontNotFound(FontDesc),
 
-    /// Unable to find metrics information on a font face.
+    /// Unable to find metrics for a font face.
     MetricsNotFont,
 
     /// The glyph could not be found in any font.
@@ -236,9 +236,7 @@ impl Display for Error {
                 write!(f, "glyph for character {:?} not found", glyph.character)
             },
             Error::UnknownFontKey => f.write_str("invalid font key"),
-            Error::MetricsNotFont => {
-                f.write_str("unable to find metrics information on a font face")
-            },
+            Error::MetricsNotFont => f.write_str("unable to find metrics for a font face"),
             Error::PlatformError(err) => write!(f, "{}", err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,13 @@ pub struct Metrics {
 /// Errors occuring when using the rasterizer.
 #[derive(Debug)]
 pub enum Error {
-    /// Couldn't find font matching description.
+    /// Unable to find a font matching the description.
     FontNotFound(FontDesc),
 
     /// Tried to get size metrics from a Face that didn't have a size.
     MissingSizeMetrics,
 
+    /// The glyph could not be found in any font.
     MissingGlyph(RasterizedGlyph),
 
     /// Requested an operation with a FontKey that isn't known to the rasterizer.
@@ -230,15 +231,15 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Error::FontNotFound(font) => write!(f, "Unable to find the font: {:?}", font),
+            Error::FontNotFound(font) => write!(f, "font {:?} not found", font),
             Error::MissingGlyph(glyph) => {
-                write!(f, "Unable to find glyph for char {}", glyph.character)
+                write!(f, "glyph for character {:?} not found", glyph.character)
             },
-            Error::UnknownFontKey => f.write_str("Tried to use a font that hasn't been loaded"),
+            Error::UnknownFontKey => f.write_str("invalid font key"),
             Error::MissingSizeMetrics => {
-                f.write_str("Tried to get size metrics from a face without a size")
+                f.write_str("tried to get size metrics from a face without a size")
             },
-            Error::PlatformError(err) => write!(f, "{:?}", err),
+            Error::PlatformError(err) => write!(f, "{}", err),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl Display for Error {
                 write!(f, "glyph for character {:?} not found", glyph.character)
             },
             Error::UnknownFontKey => f.write_str("invalid font key"),
-            Error::MetricsNotFont => f.write_str("unable to find metrics for a font face"),
+            Error::MetricsNotFont => f.write_str("metrics not found"),
             Error::PlatformError(err) => write!(f, "{}", err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub enum Error {
     FontNotFound(FontDesc),
 
     /// Unable to find metrics for a font face.
-    MetricsNotFont,
+    MetricsNotFound,
 
     /// The glyph could not be found in any font.
     MissingGlyph(RasterizedGlyph),
@@ -236,7 +236,7 @@ impl Display for Error {
                 write!(f, "glyph for character {:?} not found", glyph.character)
             },
             Error::UnknownFontKey => f.write_str("invalid font key"),
-            Error::MetricsNotFont => f.write_str("metrics not found"),
+            Error::MetricsNotFound => f.write_str("metrics not found"),
             Error::PlatformError(err) => write!(f, "{}", err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl FontKey {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct GlyphKey {
-    pub c: char,
+    pub character: char,
     pub font_key: FontKey,
     pub size: Size,
 }
@@ -149,12 +149,12 @@ impl From<f32> for Size {
 
 #[derive(Clone)]
 pub struct RasterizedGlyph {
-    pub c: char,
+    pub character: char,
     pub width: i32,
     pub height: i32,
     pub top: i32,
     pub left: i32,
-    pub buf: BitmapBuffer,
+    pub buffer: BitmapBuffer,
 }
 
 #[derive(Clone, Debug)]
@@ -169,12 +169,12 @@ pub enum BitmapBuffer {
 impl Default for RasterizedGlyph {
     fn default() -> RasterizedGlyph {
         RasterizedGlyph {
-            c: ' ',
+            character: ' ',
             width: 0,
             height: 0,
             top: 0,
             left: 0,
-            buf: BitmapBuffer::RGB(Vec::new()),
+            buffer: BitmapBuffer::RGB(Vec::new()),
         }
     }
 }
@@ -182,12 +182,12 @@ impl Default for RasterizedGlyph {
 impl fmt::Debug for RasterizedGlyph {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RasterizedGlyph")
-            .field("c", &self.c)
+            .field("character", &self.character)
             .field("width", &self.width)
             .field("height", &self.height)
             .field("top", &self.top)
             .field("left", &self.left)
-            .field("buf", &self.buf)
+            .field("buffer", &self.buffer)
             .finish()
     }
 }
@@ -207,7 +207,7 @@ pub struct Metrics {
 #[derive(Debug)]
 pub enum Error {
     /// Couldn't find font matching description.
-    MissingFont(FontDesc),
+    FontNotFound(FontDesc),
 
     /// Tried to get size metrics from a Face that didn't have a size.
     MissingSizeMetrics,
@@ -215,7 +215,7 @@ pub enum Error {
     MissingGlyph(RasterizedGlyph),
 
     /// Requested an operation with a FontKey that isn't known to the rasterizer.
-    FontNotLoaded,
+    UnknownFontKey,
 
     /// Error from platfrom's font system.
     PlatformError(String),
@@ -230,9 +230,11 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Error::MissingFont(font) => write!(f, "Unable to find the font {}", font),
-            Error::MissingGlyph(glyph) => write!(f, "Unable to find glyph for char {}", glyph.c),
-            Error::FontNotLoaded => f.write_str("Tried to use a font that hasn't been loaded"),
+            Error::FontNotFound(font) => write!(f, "Unable to find the font: {:?}", font),
+            Error::MissingGlyph(glyph) => {
+                write!(f, "Unable to find glyph for char {}", glyph.character)
+            },
+            Error::UnknownFontKey => f.write_str("Tried to use a font that hasn't been loaded"),
             Error::MissingSizeMetrics => {
                 f.write_str("Tried to get size metrics from a face without a size")
             },


### PR DESCRIPTION
This should help users identify when they failed to
get the requested glyph, since it was missing on the system.
The resulted missing glyph will be stored in 'Error::MissingGlyph',
so they can easily render it.