### PR TITLE
directwrite: Honor global ClearType setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ core-foundation-sys = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 dwrote = { version = "0.11" }
-winapi = { version = "0.3", features = ["impl-default"] }
+winapi = { version = "0.3", features = ["impl-default", "winuser"] }
 
 [features]
 force_system_fontconfig = ["servo-fontconfig/force_system_lib"]


### PR DESCRIPTION
This only uses the DWRITE_TEXTURE_CLEARTYPE_3x1 texture type if
ClearType itself is enabled elsewhere on Windows, and configures the
rendering options accordingly. The winuser feature is enabled in winapi
to allow for the checks.