### PR TITLE
Add ability to reload font cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fontconfig not checking for new fonts installed after `Rasterizer` creation when calling `Rasterizer::load_font`.
+- Fontconfig not checking for fonts installed after `Rasterizer` creation
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- On systems using Fontconfig backend newly added fonts not visible upon `Rasterizer` recreation.
+- Fontconfig not checking for new fonts installed after `Rasterizer` creation when calling `Rasterizer::load_font`.
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- On systems using Fontconfig backend newly added fonts not visible upon `Rasterizer` recreation.
+
 ## 0.3.0
 
 ### Changed

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -49,7 +49,7 @@ pub fn font_match(config: &ConfigRef, pattern: &PatternRef) -> Option<Pattern> {
 }
 
 /// Reloads the Fontconfig configuration files.
-pub fn bring_config_upto_date() {
+pub fn update_config() {
     unsafe {
         let _ = FcInitBringUptoDate();
     }

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -5,6 +5,7 @@ use foreign_types::{ForeignType, ForeignTypeRef};
 
 use fontconfig::fontconfig as ffi;
 
+use ffi::FcInitBringUptoDate;
 use ffi::FcResultNoMatch;
 use ffi::{FcFontList, FcFontMatch, FcFontSort};
 use ffi::{FcMatchFont, FcMatchPattern, FcMatchScan};
@@ -44,6 +45,13 @@ pub fn font_match(config: &ConfigRef, pattern: &PatternRef) -> Option<Pattern> {
         } else {
             Some(Pattern::from_ptr(ptr))
         }
+    }
+}
+
+/// Reloads the Fontconfig configuration files.
+pub fn bring_config_upto_date() {
+    unsafe {
+        let _ = FcInitBringUptoDate();
     }
 }
 

--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -467,7 +467,7 @@ impl PatternRef {
     ///
     /// `object` is not checked to be a valid null-terminated string.
     unsafe fn add_string(&mut self, object: &[u8], value: &str) -> bool {
-        let value = CString::new(&value[..]).unwrap();
+        let value = CString::new(value).unwrap();
         let value = value.as_ptr();
 
         FcPatternAddString(self.as_ptr(), object.as_ptr() as *mut c_char, value as *mut FcChar8)

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -91,8 +91,8 @@ pub struct FreeTypeRasterizer {
     device_pixel_ratio: f32,
 
     /// Rasterizer creation time stamp to delay lazy font config updates
-    /// in `Rasterizer::laod_font`.
-    initialization_time_stamp: Option<Instant>,
+    /// in `Rasterizer::load_font`.
+    creation_timestamp: Option<Instant>,
 }
 
 #[inline]
@@ -111,7 +111,7 @@ impl Rasterize for FreeTypeRasterizer {
             loader: FreeTypeLoader::new()?,
             fallback_lists: HashMap::new(),
             device_pixel_ratio,
-            initialization_time_stamp: Some(Instant::now()),
+            creation_timestamp: Some(Instant::now()),
         })
     }
 
@@ -164,8 +164,8 @@ impl Rasterize for FreeTypeRasterizer {
     }
 
     fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
-        if self.initialization_time_stamp.map_or(true, |t| t.elapsed() > RELOAD_DELAY) {
-            self.initialization_time_stamp = None;
+        if self.creation_timestamp.map_or(true, |t| t.elapsed() > RELOAD_DELAY) {
+            self.creation_timestamp = None;
             fc::update_config();
         }
 

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -164,7 +164,7 @@ impl Rasterize for FreeTypeRasterizer {
     }
 
     fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
-        if self.creation_timestamp.map_or(true, |t| t.elapsed() > RELOAD_DELAY) {
+        if self.creation_timestamp.map_or(true, |timestamp| timestamp.elapsed() > RELOAD_DELAY) {
             self.creation_timestamp = None;
             fc::update_config();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub enum Style {
 impl fmt::Display for Style {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Style::Specific(ref s) => f.write_str(&s),
+            Style::Specific(ref s) => f.write_str(s),
             Style::Description { slant, weight } => {
                 write!(f, "slant={:?}, weight={:?}", slant, weight)
             },


### PR DESCRIPTION
Fixes #19.

---
This functions indeed solves the problem when calling from glyph reload path in alacritty's update display routine. I was trying to do all the calling part 'on-demand', but this functions is kind of slow(it's not that slow, but slow for startup) and slows down stratup time, that's why I've decided to add separate method to update font cache.