### PR TITLE
Fix bitmap rendering with FreeType 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fontconfig not checking for fonts installed after `Rasterizer` creation
+- Bitmap rendering with FreeType 2.11.0
 
 ## 0.3.0
 


### PR DESCRIPTION
Calling `render_glyph` on bitmap fonts(emojis, etc) now returns error
with freetype 2.11, which wasn't the case before. This PR checks
whether the glyph is bitmap or not before doing any rendering.

Fixes https://github.com/alacritty/alacritty/issues/5353