### PR TITLE
Adjust font fallback behavior on macOS

### DIFF
--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -97,6 +97,20 @@ impl Descriptor {
                     // below, which prints a list of the few dozen fallback
                     // fonts that are given for Menlo Regular (English).
 
+                    // While there are still problems with font fallback on
+                    // macOS, we can improve the situation by adding Noto Sans
+                    // to the list -- only if it's available. Users who are
+                    // seeing issues with certain uncommon characters can be
+                    // advised to install Noto Sans.
+                    if get_family_names().contains(&"Noto Sans".to_string()) {
+                        if let Some(noto_regular) = descriptors_for_family("Noto Sans")
+                            .into_iter()
+                            .find(|d| d.style_name == "Regular")
+                        {
+                            fallbacks.push(noto_regular.to_font(size, false))
+                        }
+                    }
+
                     // Include Menlo at the beginning of the fallback list; it
                     // wouldn't otherwise be part of its own cascade.
                     fallbacks.insert(0, Font {


### PR DESCRIPTION
NB: I've been building Alacritty with my own fork of crossfont, and that's fine. I just thought of opening a PR in case my quasi-fix would be of use to other Mac users. (See [Alacritty issue 2800](https://github.com/alacritty/alacritty/issues/2800) for background.) If the PR isn't welcome, by all means close it.

Apart from comments, two changes have been made to the code. First, my testing has shown that Apple Symbols is already included in the cascade list being requested for Menlo Regular (English). So there's no need to add it back manually, as was done before. I wrote a test that prints the fallback list, which has around forty items (including what appear to be duplicates?). Yes, we lose ".Apple Symbols Fallback," but "Apple Symbols" itself is there.

Second, _if it's available_, we can add [Noto Sans](https://www.google.com/get/noto/) to the fallback list as another high-coverage font. I've verified that this does nothing if the font is not installed. To my knowledge, all of the characters that people have been complaining about (₽, ⸨ and ₙ come to mind) are provided in Noto Sans. With this added to the fallback list on an as-available basis, users who are seeing issues with uncommon characters could be advised to install a font. It could be a decent fix for a while. I have no idea what the path might be to getting macOS font fallback behavior in crossfont/Alacritty to be more like what we see in Terminal.app or iTerm2—where ultimately, afaict, every installed font will be checked for a glyph before giving up.

Thank you for your work on this library.