### PR TITLE
Use appropriate style fallback fonts at Core Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minimum Rust version has been bumped to 1.46.0
+- Core Text backend uses a current font as the original fallback font instead of Menlo
+
+### Fixed
+
+- Core Text backend ignoring style for font fallback
 
 ## 0.3.1
 


### PR DESCRIPTION
Previously crossfont using Core Text as backend has always returned regular style fallback fonts, even if the original font style is bold. This causes no correct rendering bold style glyph, especially for CJK characters. The reasons are below.

1. Causes font fallback frequently because many fonts have no CJK glyphs.
2. Lookups glyph at fallback fonts, but the fonts have only regular style.

We can't resolve No. 1 but instead can do No. 2. This commit returns appropriate style fallback fonts corresponding to the original font style.

This can check by a command below.

```bash
echo -e 'Hello, こんにちは, 你好, 안녕하세요\n\e[1mHello, こんにちは, 你好, 안녕하세요\e[0m'
```
These are screenshots on alacritty with this PR's branch.

Before

![Screen Shot 2021-10-25 at 19 19 38](https://user-images.githubusercontent.com/12132068/138686301-887027ee-b9bd-488c-872b-65f20cf5c3cb.png)

After

![Screen Shot 2021-10-25 at 19 17 49](https://user-images.githubusercontent.com/12132068/138686343-efc14e3a-822e-4699-9e24-506cc0faf683.png)

Note that this fix should affect even if italic or bold italic for CJK characters in theory, but not in fact. Maybe no italic or bold italic fonts are installed by default in macOS. This is the same even if terminal.app or iTerm2 by default.