### PR TITLE
Add harfbuzz feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 servo-fontconfig = "0.5.1"
 freetype-rs = "0.26"
+harfbuzz_rs = { version = "2.0.1", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.build-dependencies]
 pkg-config = "0.3"
@@ -36,3 +37,4 @@ winapi = { version = "0.3", features = ["impl-default"] }
 
 [features]
 force_system_fontconfig = ["servo-fontconfig/force_system_lib"]
+harfbuzz = ["harfbuzz_rs"]

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -116,7 +116,7 @@ pub struct Rasterizer {
 }
 
 impl crate::Rasterize for Rasterizer {
-    fn new(device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Rasterizer, Error> {
+    fn new(device_pixel_ratio: f32, use_thin_strokes: bool, _: bool) -> Result<Rasterizer, Error> {
         Ok(Rasterizer {
             fonts: HashMap::new(),
             keys: HashMap::new(),

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -135,7 +135,7 @@ impl DirectWriteRasterizer {
 }
 
 impl crate::Rasterize for DirectWriteRasterizer {
-    fn new(device_pixel_ratio: f32, _: bool) -> Result<DirectWriteRasterizer, Error> {
+    fn new(device_pixel_ratio: f32, _: bool, _: bool) -> Result<DirectWriteRasterizer, Error> {
         Ok(DirectWriteRasterizer {
             fonts: HashMap::new(),
             keys: HashMap::new(),


### PR DESCRIPTION
This revives alacritty/alacritty#2677, adding a `shape` method to `FreeTypeRasterizer` when the feature flag is enabled. Ideally it would be on the `Rasterizer` trait, but I haven't learned how to add macos and windows support yet.

EDIT: note that the CI is not ran with the feature enabled at all. Let me know if I should change CI to also run harfbuzz feature enabled.