### PR TITLE
Support custom glyph indices in GlyphKey

### DIFF
--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -345,7 +345,7 @@ macro_rules! string_accessor {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PatternHash(pub u32);
 
-#[derive(Hash, Eq, PartialEq, Debug)]
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub struct FtFaceLocation {
     pub path: PathBuf,
     pub index: isize,

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -680,7 +680,7 @@ impl FreeTypeLoader {
 
             let ft_face = match self.ft_faces.get(&ft_face_location) {
                 Some(ft_face) => Rc::clone(ft_face),
-                None => self.load_ft_face(ft_face_location)?,
+                None => self.load_ft_face(ft_face_location.clone())?,
             };
 
             // This will be different for each font so we can't use a constant but we don't want to

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -63,6 +63,7 @@ pub struct FaceLoadingProperties {
     matrix: Option<Matrix>,
     pixelsize_fixup_factor: Option<f64>,
     ft_face: Rc<FtFace>,
+    pub location: FtFaceLocation,
     rgba: Rgba,
     placeholder_glyph_index: u32,
 }
@@ -718,6 +719,7 @@ impl FreeTypeLoader {
                 matrix,
                 pixelsize_fixup_factor,
                 ft_face,
+                location: ft_face_location,
                 rgba,
                 placeholder_glyph_index,
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::fmt::{self, Display, Formatter};
 use std::ops::{Add, Mul};
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 // If target isn't macos or windows, reexport everything from ft.
@@ -318,4 +319,9 @@ pub trait Rasterize {
 
     /// Update the Rasterizer's DPI factor.
     fn update_dpr(&mut self, device_pixel_ratio: f32);
+
+    /// Get the path of a font by its key.
+    ///
+    /// This is useful when you want to load the font for another library.
+    fn font_path(&self, _: FontKey) -> Result<&Path, Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,14 +120,17 @@ impl GlyphId {
     }
 
     pub fn as_char(self) -> Option<char> {
+        use std::convert::TryFrom;
         let value = self.value();
 
         if value & C_BIT == 0 {
             None
         } else {
-            // SAFETY: this is safe because we never construct a `GlyphId` with the C_BIT set
-            // with an invalid character.
-            unsafe { Some(char::from_u32_unchecked(value & C_MASK)) }
+            match char::try_from(value & C_MASK) {
+                Ok(c) => Some(c),
+                // we never construct a `GlyphId` with the C_BIT set with an invalid character.
+                Err(_) => unreachable!(),
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,14 @@ impl GlyphId {
         Self(c as u32 | C_BIT)
     }
 
+    /// Creates a `GlyphId` representing a glyph index.
+    ///
+    /// The index must not have the most significant bit set.
+    pub fn with_glyph_index(n: u32) -> Self {
+        assert!(n < C_BIT);
+        Self(n)
+    }
+
     /// Creates a `GlyphId` representing a placeholder value.
     pub fn placeholder() -> Self {
         Self(0)


### PR DESCRIPTION
This is a breaking change.

Also publicizes some fields for FreeType types that ligature support for alacritty is going to need. 

Tested locally with targets:

```
x86_64-apple-darwin
x86_64-pc-windows-gnu
x86_64-unknown-linux-musl
```