### PR TITLE
Add proportional font support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- FreeType proportional font metrics using `RasterizedGlyph::advance` and `Rasterize::kerning`
+
 ### Changed
 
 - Minimum Rust version has been bumped to 1.56.0

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -168,6 +168,10 @@ impl crate::Rasterize for Rasterizer {
         }
     }
 
+    fn kerning(&mut self, left: GlyphKey, right: GlyphKey) -> (f32, f32) {
+        (0., 0.)
+    }
+
     fn update_dpr(&mut self, device_pixel_ratio: f32) {
         self.device_pixel_ratio = device_pixel_ratio;
     }
@@ -396,6 +400,7 @@ impl Font {
                 height: 0,
                 top: 0,
                 left: 0,
+                advance: (0, 0),
                 buffer: BitmapBuffer::Rgb(Vec::new()),
             };
         }
@@ -461,6 +466,7 @@ impl Font {
             top: (bounds.size.height + bounds.origin.y).ceil() as i32,
             width: rasterized_width as i32,
             height: rasterized_height as i32,
+            advance: (0, 0),
             buffer,
         }
     }

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -90,6 +90,7 @@ impl DirectWriteRasterizer {
             height: (bounds.bottom - bounds.top) as i32,
             top: -bounds.top,
             left: bounds.left,
+            advance: (0, 0),
             buffer,
         })
     }
@@ -249,6 +250,10 @@ impl crate::Rasterize for DirectWriteRasterizer {
         } else {
             Ok(rasterized_glyph)
         }
+    }
+
+    fn kerning(&mut self, left: GlyphKey, right: GlyphKey) -> (f32, f32) {
+        (0., 0.)
     }
 
     fn update_dpr(&mut self, device_pixel_ratio: f32) {

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -203,8 +203,8 @@ impl Rasterize for FreeTypeRasterizer {
             }
         }
 
-        // Transform glyphs with the matrix from Fontconfig. Primarily used to generate italics.
         let advance = unsafe {
+            // Transform glyphs with the matrix from Fontconfig. Primarily used to generate italics.
             let raw_glyph = face.ft_face.raw().glyph;
             if let Some(matrix) = face.matrix.as_ref() {
                 // Check that the glyph is a vectorial outline, not a bitmap.
@@ -249,6 +249,10 @@ impl Rasterize for FreeTypeRasterizer {
                         f64::from(pixelsize) / f64::from(metrics.y_ppem)
                     },
                 };
+
+                // Scale glyph advance.
+                rasterized_glyph.advance.0 = (advance.0 as f64 * fixup_factor).round() as i32;
+                rasterized_glyph.advance.1 = (advance.1 as f64 * fixup_factor).round() as i32;
 
                 rasterized_glyph = downsample_bitmap(rasterized_glyph, fixup_factor);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,14 @@ impl From<f32> for Size {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RasterizedGlyph {
     pub character: char,
     pub width: i32,
     pub height: i32,
     pub top: i32,
     pub left: i32,
+    pub advance: (i32, i32),
     pub buffer: BitmapBuffer,
 }
 
@@ -174,25 +175,13 @@ impl Default for RasterizedGlyph {
             height: 0,
             top: 0,
             left: 0,
+            advance: (0, 0),
             buffer: BitmapBuffer::Rgb(Vec::new()),
         }
     }
 }
 
-impl fmt::Debug for RasterizedGlyph {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("RasterizedGlyph")
-            .field("character", &self.character)
-            .field("width", &self.width)
-            .field("height", &self.height)
-            .field("top", &self.top)
-            .field("left", &self.left)
-            .field("buffer", &self.buffer)
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Metrics {
     pub average_advance: f64,
     pub line_height: f64,
@@ -259,4 +248,7 @@ pub trait Rasterize {
 
     /// Update the Rasterizer's DPI factor.
     fn update_dpr(&mut self, device_pixel_ratio: f32);
+
+    /// Kerning between two characters.
+    fn kerning(&mut self, left: GlyphKey, right: GlyphKey) -> (f32, f32);
 }


### PR DESCRIPTION
Since crossfont was previously used solely by Alacritty, there was no
need for anything other than monospaced fonts. This patch adds minimal
proportional font support to the FreeType backend.

The most relevant part for proportional fonts is using the glyph's
individual advance rather than the font metric's advance. This is
exposed as a new `advance` field on `RasterizedGlyph`.

Besides advance, it's also possible for two rasterized glyphs to be
moved closer together by the font in a process called kerning. Crossfont
mimics the FreeType API here and provides the `kerning` method which
returns the relative offset of the second of two glyphs. Kerning for
OpenType fonts implemented in a `GPOS` table is not supported.