### PR TITLE
filter on is_enabled

### DIFF
--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -297,7 +297,10 @@ fn cascade_list_for_languages(ct_font: &CTFont, languages: &[String]) -> Vec<Des
     let list = ct_cascade_list_for_languages(ct_font, &langarr);
 
     // Convert CFArray to Vec<Descriptor>.
-    list.into_iter().map(|fontdesc| Descriptor::new(fontdesc.clone())).collect()
+    list.into_iter()
+        .filter(|fontdesc| fontdesc.is_enabled())
+        .map(|fontdesc| Descriptor::new(fontdesc.clone()))
+        .collect()
 }
 
 /// Get descriptors for family name.


### PR DESCRIPTION
Based on discussion in alacritty/alacritty#6108. 

This change in crossfont only works with associated changes in core-text. 

Here is the change that would need to be applied to the [servo/core-foundation-rs](https://github.com/servo/core-foundation-rs/) repository. 

```diff
diff --git a/core-text/src/font_descriptor.rs b/core-text/src/font_descriptor.rs
index c70495c..234c6b6 100644
--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -214,9 +214,34 @@ impl CTFontDescriptor {
         }
     }
 
+    fn get_i32_attribute(&self, attribute: CFStringRef) -> Option<i32> {
+        unsafe {
+            let value = CTFontDescriptorCopyAttribute(self.0, attribute);
+            if value.is_null() {
+                return None
+            }
+
+            let value = CFType::wrap_under_create_rule(value);
+            assert!(value.instance_of::<CFNumber>());
+            let n = CFNumber::wrap_under_get_rule(value.as_CFTypeRef() as CFNumberRef);
+            n.to_i32()
+        }
+    }
+
 }
 
 impl CTFontDescriptor {
+    pub fn is_enabled(&self) -> bool {
+        unsafe {
+            let value = self.get_i32_attribute(kCTFontEnabledAttribute);
+            if value.is_none() {
+                return false
+            }
+            let value = value.unwrap();
+            value != 0
+        }
+    }
+
     pub fn family_name(&self) -> String {
         unsafe {
             let value = self.get_string_attribute(kCTFontFamilyNameAttribute);
```

I'm going to **try** to get this same functionality into crossfont, but my initial stabs at it are proving difficult. 

* I'm not even sure it's good Rust code to begin with. :)
* the core-text code is already doing a lot of magic around bridging Rust and CF types, and I can't 100% tell how to move that over. 

I'm going to keep plugging at it, but wanted to start this PR and tag @chrisduerr and @kchibisov in case they had any initial thoughts. 