### PR TITLE
Don't load disabled fonts on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2
+
+### Fixed
+
+- Crash on macOS when loading disabled font
+
 ## 0.4.1
 
 ### Fixed


### PR DESCRIPTION
This commit fixes crash due to crossfont trying to load disabled font.
Before loading the font, we ensure now that it's enabled.