### PR TITLE
Rework `Size` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Size` now uses 6 floating point digits precision instead of rounding to 0.5.
 - Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, `Size::change_px`, and `Size::scale`.
-- Remove `Rasterizer::update_dpr`; users should scale font themselves.
+- Remove `Rasterizer::update_dpr`; users should scale fonts themselves.
 
 ## 0.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - `Size` now uses 6 floating point digits precision instead of rounding to 0.5.
-- Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, `Size::change_px`, and `Size::scale`.
+- Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, and `Size::scale`.
 - Remove `Rasterizer::update_dpr`; users should scale fonts themselves.
 
 ## 0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Changed
+
+- `Size` now uses 6 floating point digits precision instead of rounding to 0.5.
+- Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, `Size::change_px`, and `Size::scale`.
+- Remove `Rasterizer::update_dpr`; users should scale font themselves.
+
 ## 0.5.2
 
 - Minimum Rust version has been bumped to 1.65

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -102,12 +102,11 @@ impl Descriptor {
 pub struct CoreTextRasterizer {
     fonts: HashMap<FontKey, Font>,
     keys: HashMap<(FontDesc, Size), FontKey>,
-    device_pixel_ratio: f32,
 }
 
 impl crate::Rasterize for CoreTextRasterizer {
-    fn new(device_pixel_ratio: f32) -> Result<CoreTextRasterizer, Error> {
-        Ok(CoreTextRasterizer { fonts: HashMap::new(), keys: HashMap::new(), device_pixel_ratio })
+    fn new() -> Result<CoreTextRasterizer, Error> {
+        Ok(CoreTextRasterizer { fonts: HashMap::new(), keys: HashMap::new() })
     }
 
     /// Get metrics for font specified by FontKey.
@@ -118,7 +117,7 @@ impl crate::Rasterize for CoreTextRasterizer {
     }
 
     fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
-        let scaled_size = Size::new(size.as_f32_pts() * self.device_pixel_ratio);
+        let scaled_size = Size::new(size.as_pt());
         self.keys.get(&(desc.to_owned(), scaled_size)).map(|k| Ok(*k)).unwrap_or_else(|| {
             let font = self.get_font(desc, size)?;
             let key = FontKey::next();
@@ -156,10 +155,6 @@ impl crate::Rasterize for CoreTextRasterizer {
     fn kerning(&mut self, _left: GlyphKey, _right: GlyphKey) -> (f32, f32) {
         (0., 0.)
     }
-
-    fn update_dpr(&mut self, device_pixel_ratio: f32) {
-        self.device_pixel_ratio = device_pixel_ratio;
-    }
 }
 
 impl CoreTextRasterizer {
@@ -173,7 +168,7 @@ impl CoreTextRasterizer {
         for descriptor in descriptors {
             if descriptor.style_name == style {
                 // Found the font we want.
-                let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
+                let scaled_size = f64::from(size.as_pt());
                 let font = descriptor.to_font(scaled_size, true);
                 return Ok(font);
             }
@@ -191,7 +186,7 @@ impl CoreTextRasterizer {
     ) -> Result<Font, Error> {
         let bold = weight == Weight::Bold;
         let italic = slant != Slant::Normal;
-        let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
+        let scaled_size = f64::from(size.as_pt());
 
         let descriptors = descriptors_for_family(&desc.name[..]);
         for descriptor in descriptors {

--- a/src/darwin/mod.rs
+++ b/src/darwin/mod.rs
@@ -117,13 +117,13 @@ impl crate::Rasterize for CoreTextRasterizer {
     }
 
     fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
-        let scaled_size = Size::new(size.as_pt());
-        self.keys.get(&(desc.to_owned(), scaled_size)).map(|k| Ok(*k)).unwrap_or_else(|| {
+        let size = Size::new(size.as_pt());
+        self.keys.get(&(desc.to_owned(), size)).map(|k| Ok(*k)).unwrap_or_else(|| {
             let font = self.get_font(desc, size)?;
             let key = FontKey::next();
 
             self.fonts.insert(key, font);
-            self.keys.insert((desc.clone(), scaled_size), key);
+            self.keys.insert((desc.clone(), size), key);
 
             Ok(key)
         })
@@ -168,8 +168,8 @@ impl CoreTextRasterizer {
         for descriptor in descriptors {
             if descriptor.style_name == style {
                 // Found the font we want.
-                let scaled_size = f64::from(size.as_pt());
-                let font = descriptor.to_font(scaled_size, true);
+                let size = f64::from(size.as_pt());
+                let font = descriptor.to_font(size, true);
                 return Ok(font);
             }
         }
@@ -186,11 +186,11 @@ impl CoreTextRasterizer {
     ) -> Result<Font, Error> {
         let bold = weight == Weight::Bold;
         let italic = slant != Slant::Normal;
-        let scaled_size = f64::from(size.as_pt());
+        let size = f64::from(size.as_pt());
 
         let descriptors = descriptors_for_family(&desc.name[..]);
         for descriptor in descriptors {
-            let font = descriptor.to_font(scaled_size, true);
+            let font = descriptor.to_font(size, true);
             if font.is_bold() == bold && font.is_italic() == italic {
                 // Found the font we want.
                 return Ok(font);

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -334,7 +334,7 @@ impl FreeTypeRasterizer {
     /// Load a font face according to `FontDesc`.
     fn get_face(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
         // Adjust for DPR.
-        let size = f64::from(size.as_pt() * 96. / 72.);
+        let size = f64::from(size.as_px());
 
         let config = fc::Config::get_current();
         let mut pattern = Pattern::new();

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -88,7 +88,6 @@ impl fmt::Debug for FaceLoadingProperties {
 pub struct FreeTypeRasterizer {
     loader: FreeTypeLoader,
     fallback_lists: HashMap<FontKey, FallbackList>,
-    device_pixel_ratio: f32,
 
     /// Rasterizer creation time stamp to delay lazy font config updates
     /// in `Rasterizer::load_font`.
@@ -133,11 +132,10 @@ impl IntoF32 for i64 {
 }
 
 impl Rasterize for FreeTypeRasterizer {
-    fn new(device_pixel_ratio: f32) -> Result<FreeTypeRasterizer, Error> {
+    fn new() -> Result<FreeTypeRasterizer, Error> {
         Ok(FreeTypeRasterizer {
             loader: FreeTypeLoader::new()?,
             fallback_lists: HashMap::new(),
-            device_pixel_ratio,
             creation_timestamp: Some(Instant::now()),
         })
     }
@@ -204,9 +202,7 @@ impl Rasterize for FreeTypeRasterizer {
         let font_key = self.face_for_glyph(glyph_key);
         let face = &self.loader.faces[&font_key];
         let index = face.ft_face.get_char_index(glyph_key.character as usize);
-        let pixelsize = face
-            .non_scalable
-            .unwrap_or_else(|| glyph_key.size.as_f32_pts() * self.device_pixel_ratio * 96. / 72.);
+        let pixelsize = face.non_scalable.unwrap_or_else(|| glyph_key.size.as_px() as f32);
 
         if !face.colored_bitmap {
             face.ft_face.set_char_size(to_freetype_26_6(pixelsize), 0, 0, 0)?;
@@ -308,10 +304,6 @@ impl Rasterize for FreeTypeRasterizer {
 
         (from_freetype_26_6(kerning.x), from_freetype_26_6(kerning.y))
     }
-
-    fn update_dpr(&mut self, device_pixel_ratio: f32) {
-        self.device_pixel_ratio = device_pixel_ratio;
-    }
 }
 
 impl From<Slant> for fc::Slant {
@@ -342,7 +334,7 @@ impl FreeTypeRasterizer {
     /// Load a font face according to `FontDesc`.
     fn get_face(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
         // Adjust for DPR.
-        let size = f64::from(size.as_f32_pts() * self.device_pixel_ratio * 96. / 72.);
+        let size = f64::from(size.as_pt() * 96. / 72.);
 
         let config = fc::Config::get_current();
         let mut pattern = Pattern::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub struct Size(u32);
 impl Size {
     /// Create a new `Size` from a f32 size in points.
     ///
-    /// The font size is automatically clamped to supported range of [1.; 4000.] pt.
+    /// The font size is automatically clamped to supported range of `[1.; 3999.]` pt.
     pub fn new(size: f32) -> Size {
         let size = size.clamp(1., MAX_FONT_PT_SIZE);
         Size((size * Self::factor()) as u32)
@@ -124,12 +124,6 @@ impl Size {
     pub fn from_px(size: u16) -> Self {
         let pt = size as f32 * 72. / 96.;
         Size::new(pt)
-    }
-
-    /// Change font size in px by the given amount.
-    pub fn change_px(self, delta: i32) -> Self {
-        let new_size = (self.as_px() as i32 + delta).clamp(1, u16::MAX as i32) as u16;
-        Size::from_px(new_size)
     }
 
     /// Scale font size by the given amount.


### PR DESCRIPTION
--

There're likely better ways to do that, but it really sucks to deal with those sizes on hidpi, since you can't pick some of them.

We also can't use `f32` directly, since it's not `Hash`, so we could only do thins like that with fractions, etc.