### PR TITLE
Make `Size::as_px` return f32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `Size::as_px` now returns `f32`.
+
 ## 0.6.0
 
-## Changed
+### Changed
 
 - `Size` now uses 6 floating point digits precision instead of rounding to 0.5.
 - Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, and `Size::scale`.

--- a/src/directwrite/mod.rs
+++ b/src/directwrite/mod.rs
@@ -47,7 +47,7 @@ impl DirectWriteRasterizer {
         character: char,
         glyph_index: u16,
     ) -> Result<RasterizedGlyph, Error> {
-        let em_size = f32::from(size.as_px());
+        let em_size = size.as_px();
 
         let glyph_run = DWRITE_GLYPH_RUN {
             fontFace: unsafe { face.as_ptr() },
@@ -148,7 +148,7 @@ impl crate::Rasterize for DirectWriteRasterizer {
         let face = &self.get_loaded_font(key)?.face;
         let vmetrics = face.metrics().metrics0();
 
-        let scale = f32::from(size.as_px()) / f32::from(vmetrics.designUnitsPerEm);
+        let scale = size.as_px() / f32::from(vmetrics.designUnitsPerEm);
 
         let underline_position = f32::from(vmetrics.underlinePosition) * scale;
         let underline_thickness = f32::from(vmetrics.underlineThickness) * scale;

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -202,7 +202,7 @@ impl Rasterize for FreeTypeRasterizer {
         let font_key = self.face_for_glyph(glyph_key);
         let face = &self.loader.faces[&font_key];
         let index = face.ft_face.get_char_index(glyph_key.character as usize);
-        let pixelsize = face.non_scalable.unwrap_or_else(|| glyph_key.size.as_px() as f32);
+        let pixelsize = face.non_scalable.unwrap_or_else(|| glyph_key.size.as_px());
 
         if !face.colored_bitmap {
             face.ft_face.set_char_size(to_freetype_26_6(pixelsize), 0, 0, 0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ impl Size {
     }
 
     /// Get size in `px`.
-    pub fn as_px(self) -> u16 {
-        (self.as_pt() * 96. / 72.).trunc() as u16
+    pub fn as_px(self) -> f32 {
+        self.as_pt() * 96. / 72.
     }
 
     /// Get the size in `pt`.


### PR DESCRIPTION
Users can round themselves if they need that.