### PR TITLE
Switch `Size::from_px` constructor to `f32`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Size::as_px` now returns `f32`.
+- `Size::as_px` and `Size::from_px` now use `f32` type
 
 ## 0.6.0
 
 ### Changed
 
-- `Size` now uses 6 floating point digits precision instead of rounding to 0.5.
-- Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, and `Size::scale`.
-- Remove `Rasterizer::update_dpr`; users should scale fonts themselves.
+- `Size` now uses 6 floating point digits precision instead of rounding to 0.5
+- Add `Size::from_px`, `Size::as_px`, `Size::as_pt`, and `Size::scale`
+- Remove `Rasterizer::update_dpr`; users should scale fonts themselves
 
 ## 0.5.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,8 @@ impl Size {
     /// Create a new `Size` from px.
     ///
     /// The value will be clamped to the pt range of [`Size::new`].
-    pub fn from_px(size: u16) -> Self {
-        let pt = size as f32 * 72. / 96.;
+    pub fn from_px(size: f32) -> Self {
+        let pt = size * 72. / 96.;
         Size::new(pt)
     }
 


### PR DESCRIPTION
1f8e5db changed the `Size::as_px` method to return a floating point value instead of an integer. This patch ensures the constructor is consistent with that.