### PR TITLE
Use yeslogic-fontconfig-sys instead of servo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, and `Removed`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- **Breaking** fontconfig system library provider changed to yeslogic-fontcontconfig-sys
+- **Breaking** freetype-rs bumped to 0.36.0
+
 ## 0.7.0
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ foreign-types = "0.5"
 log = "0.4"
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
-servo-fontconfig = "0.5.1"
-freetype-rs = "0.26"
+yeslogic-fontconfig-sys = "5.0.0"
+freetype-rs = "0.36.0"
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.build-dependencies]
 pkg-config = "0.3"
@@ -36,6 +36,3 @@ once_cell = "1.12"
 [target.'cfg(windows)'.dependencies]
 dwrote = { version = "0.11" }
 winapi = { version = "0.3", features = ["impl-default"] }
-
-[features]
-force_system_fontconfig = ["servo-fontconfig/force_system_lib"]

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -3,17 +3,17 @@ use std::ptr;
 
 use foreign_types::{ForeignType, ForeignTypeRef};
 
-use fontconfig::fontconfig as ffi;
+use fontconfig_sys as ffi;
 
+use ffi::constants::{FC_SLANT_ITALIC, FC_SLANT_OBLIQUE, FC_SLANT_ROMAN};
+use ffi::constants::{FC_WEIGHT_BLACK, FC_WEIGHT_BOLD, FC_WEIGHT_EXTRABLACK, FC_WEIGHT_EXTRABOLD};
+use ffi::constants::{FC_WEIGHT_BOOK, FC_WEIGHT_MEDIUM, FC_WEIGHT_REGULAR, FC_WEIGHT_SEMIBOLD};
+use ffi::constants::{FC_WEIGHT_EXTRALIGHT, FC_WEIGHT_LIGHT, FC_WEIGHT_THIN};
 use ffi::FcInitBringUptoDate;
 use ffi::FcResultNoMatch;
 use ffi::{FcFontList, FcFontMatch, FcFontSort};
 use ffi::{FcMatchFont, FcMatchPattern, FcMatchScan};
 use ffi::{FcSetApplication, FcSetSystem};
-use ffi::{FC_SLANT_ITALIC, FC_SLANT_OBLIQUE, FC_SLANT_ROMAN};
-use ffi::{FC_WEIGHT_BLACK, FC_WEIGHT_BOLD, FC_WEIGHT_EXTRABLACK, FC_WEIGHT_EXTRABOLD};
-use ffi::{FC_WEIGHT_BOOK, FC_WEIGHT_MEDIUM, FC_WEIGHT_REGULAR, FC_WEIGHT_SEMIBOLD};
-use ffi::{FC_WEIGHT_EXTRALIGHT, FC_WEIGHT_LIGHT, FC_WEIGHT_THIN};
 
 pub mod config;
 pub use config::{Config, ConfigRef};


### PR DESCRIPTION
The servo crate is not maintained anymore.

This also bumps freetype-rs along the way, since it had circular dependency.

Closes: #64

--

I somehow merged it into the wrong branch.