### PR TITLE
Use more `objc2` framework crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,6 @@ foreign-types = "0.5"
 pkg-config = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10.0"
-core-text = "21.0.0"
-core-graphics = "0.24.0"
-core-foundation-sys = "0.8.4"
 once_cell = "1.12"
 objc2 = "0.6.1"
 objc2-foundation = { version = "0.3.1", default-features = false, features = [
@@ -38,6 +34,33 @@ objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "NSString",
     "NSUserDefaults",
     "NSValue",
+] }
+objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "CFArray",
+    "CFBase",
+    "CFCGTypes",
+    "CFDictionary",
+    "CFNumber",
+    "CFSet",
+    "CFString",
+    "CFURL",
+] }
+objc2-core-text = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "objc2-core-graphics",
+    "CTFont",
+    "CTFontCollection",
+    "CTFontDescriptor",
+    "CTFontTraits",
+] }
+objc2-core-graphics = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "CGBitmapContext",
+    "CGColorSpace",
+    "CGContext",
+    "CGFont",
+    "CGImage",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "crossfont"
 version = "0.8.0"
 description = "Cross platform native font loading and rasterization"
-authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
+authors = [
+    "Christian Duerr <contact@christianduerr.com>",
+    "Joe Wilm <joe@jwilm.com>",
+]
 repository = "https://github.com/alacritty/crossfont.git"
 documentation = "https://docs.rs/crossfont"
 license = "Apache-2.0"
@@ -13,13 +16,12 @@ edition = "2021"
 rust-version = "1.77.0"
 
 [dependencies]
-libc = "0.2"
-foreign-types = "0.5"
 log = "0.4"
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 yeslogic-fontconfig-sys = "6.0.0"
 freetype-rs = "0.36.0"
+foreign-types = "0.5"
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.build-dependencies]
 pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ core-text = "21.0.0"
 core-graphics = "0.24.0"
 core-foundation-sys = "0.8.4"
 once_cell = "1.12"
-objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.2", features = [
+objc2 = "0.6.1"
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
     "NSString",
     "NSUserDefaults",
     "NSValue",

--- a/src/darwin/byte_order.rs
+++ b/src/darwin/byte_order.rs
@@ -1,15 +1,5 @@
 //! Constants for bitmap byte order.
 
-#![allow(non_upper_case_globals)]
-pub const kCGBitmapByteOrder32Little: u32 = 2 << 12;
-pub const kCGBitmapByteOrder32Big: u32 = 4 << 12;
-
-#[cfg(target_endian = "little")]
-pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Little;
-
-#[cfg(target_endian = "big")]
-pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Big;
-
 #[cfg(target_endian = "little")]
 pub fn extract_rgba(bytes: &[u8]) -> Vec<u8> {
     let pixels = bytes.len() / 4;

--- a/src/ft/fc/object_set.rs
+++ b/src/ft/fc/object_set.rs
@@ -1,6 +1,5 @@
+use std::ffi::c_char;
 use std::ptr::NonNull;
-
-use libc::c_char;
 
 use super::ffi::{FcObjectSet, FcObjectSetAdd, FcObjectSetCreate, FcObjectSetDestroy};
 use foreign_types::{foreign_type, ForeignTypeRef};

--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -1,11 +1,10 @@
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, c_double, c_int, CStr, CString};
 use std::fmt;
 use std::path::PathBuf;
 use std::ptr::{self, NonNull};
 use std::str;
 
 use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
-use libc::{c_char, c_double, c_int};
 
 use super::ffi::FcMatrix;
 use super::ffi::FcResultMatch;

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -2,6 +2,7 @@
 
 use std::cmp::{min, Ordering};
 use std::collections::HashMap;
+use std::ffi::{c_long, c_uint};
 use std::fmt::{self, Formatter};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -10,7 +11,6 @@ use freetype::face::LoadFlag;
 use freetype::tt_os2::TrueTypeOS2Table;
 use freetype::{self, Library, Matrix};
 use freetype::{freetype_sys, Face as FtFace};
-use libc::{c_long, c_uint};
 use log::{debug, trace};
 
 pub mod fc;
@@ -71,15 +71,18 @@ impl fmt::Debug for FaceLoadingProperties {
         f.debug_struct("Face")
             .field("ft_face", &self.ft_face)
             .field("load_flags", &self.load_flags)
-            .field("render_mode", &match self.render_mode {
-                freetype::RenderMode::Normal => "Normal",
-                freetype::RenderMode::Light => "Light",
-                freetype::RenderMode::Mono => "Mono",
-                freetype::RenderMode::Lcd => "Lcd",
-                freetype::RenderMode::LcdV => "LcdV",
-                freetype::RenderMode::Max => "Max",
-                freetype::RenderMode::Sdf => "Sdf",
-            })
+            .field(
+                "render_mode",
+                &match self.render_mode {
+                    freetype::RenderMode::Normal => "Normal",
+                    freetype::RenderMode::Light => "Light",
+                    freetype::RenderMode::Mono => "Mono",
+                    freetype::RenderMode::Lcd => "Lcd",
+                    freetype::RenderMode::LcdV => "LcdV",
+                    freetype::RenderMode::Max => "Max",
+                    freetype::RenderMode::Sdf => "Sdf",
+                },
+            )
             .field("lcd_filter", &self.lcd_filter)
             .finish()
     }


### PR DESCRIPTION
Remove a few unnecessary dependencies, update `objc2`, and use more of the framework crates from that.

Motivation: The `core-foundation`, `core-text` and `core-graphics` crates are being deprecated, see https://github.com/servo/core-foundation-rs/issues/729.

It'd be nice if we could get a release after this.