### PR TITLE
Ignore scalable colored fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Ignore colored SVG fonts in fontconfig backend
+
 ## 0.9.0
 
 ### Changed

--- a/src/ft/fc/char_set.rs
+++ b/src/ft/fc/char_set.rs
@@ -55,11 +55,12 @@ impl CharSetRef {
         }
     }
 
-    pub fn merge(&self, other: &CharSetRef) {
+    pub fn merge(&self, other: &CharSetRef) -> bool {
         unsafe {
             // Value is just an indicator whether something was added or not.
             let mut value: FcBool = 0;
             FcCharSetMerge(self.as_ptr() as _, other.as_ptr() as _, &mut value);
+            value != 0
         }
     }
 }

--- a/src/ft/fc/font_set.rs
+++ b/src/ft/fc/font_set.rs
@@ -49,7 +49,7 @@ impl<'a> IntoIterator for &'a FontSet {
     fn into_iter(self) -> Iter<'a> {
         let num_fonts = unsafe { (*self.as_ptr()).nfont as isize };
 
-        trace!("Number of fonts is {}", num_fonts);
+        trace!("Number of fonts is {num_fonts}");
 
         Iter { font_set: self.deref(), num_fonts: num_fonts as _, current: 0 }
     }
@@ -62,7 +62,7 @@ impl<'a> IntoIterator for &'a FontSetRef {
     fn into_iter(self) -> Iter<'a> {
         let num_fonts = unsafe { (*self.as_ptr()).nfont as isize };
 
-        trace!("Number of fonts is {}", num_fonts);
+        trace!("Number of fonts is {num_fonts}");
 
         Iter { font_set: self, num_fonts: num_fonts as _, current: 0 }
     }

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -60,7 +60,8 @@ pub fn font_sort(config: &ConfigRef, pattern: &PatternRef) -> Option<FontSet> {
         FcFontSort(
             config.as_ptr(),
             pattern.as_ptr(),
-            0, // Don't trim font list to later exclude fonts we can not render.
+            // Disable font list trimming, since we manually exclude fonts we cannot render.
+            0,
             ptr::null_mut(),
             &mut result,
         )

--- a/src/ft/fc/mod.rs
+++ b/src/ft/fc/mod.rs
@@ -60,7 +60,7 @@ pub fn font_sort(config: &ConfigRef, pattern: &PatternRef) -> Option<FontSet> {
         FcFontSort(
             config.as_ptr(),
             pattern.as_ptr(),
-            1, // Trim font list.
+            0, // Don't trim font list to later exclude fonts we can not render.
             ptr::null_mut(),
             &mut result,
         )

--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::ptr::{self, NonNull};
 use std::str;
 
+use fontconfig_sys::FcPatternReference;
 use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
 use libc::{c_char, c_double, c_int};
 
@@ -410,6 +411,7 @@ impl PatternRef {
         scalable() => b"scalable\0",
         symbol() => b"symbol\0",
         color() => b"color\0",
+        outline() => b"outline\0",
         minspace() => b"minspace\0",
         embolden() => b"embolden\0",
         embeddedbitmap() => b"embeddedbitmap\0",
@@ -600,5 +602,10 @@ impl PatternRef {
         unsafe {
             FcDefaultSubstitute(self.as_ptr());
         }
+    }
+
+    pub fn strong_count(&self) -> Pattern {
+        unsafe { FcPatternReference(self.as_ptr()) }
+        unsafe { Pattern(NonNull::new_unchecked(self.as_ptr())) }
     }
 }

--- a/src/ft/fc/pattern.rs
+++ b/src/ft/fc/pattern.rs
@@ -604,7 +604,7 @@ impl PatternRef {
         }
     }
 
-    pub fn strong_count(&self) -> Pattern {
+    pub fn upgrade(&self) -> Pattern {
         unsafe { FcPatternReference(self.as_ptr()) }
         unsafe { Pattern(NonNull::new_unchecked(self.as_ptr())) }
     }

--- a/src/ft/mod.rs
+++ b/src/ft/mod.rs
@@ -397,10 +397,10 @@ impl FreeTypeRasterizer {
                 // Exclude fonts that don't contribute to the coverage, since those won't
                 // be picked up ever.
                 //
-                // We could have done that with `font_sort`, but given that we must filter
-                // specific fonts, we do it that way.
+                // We can not do this with `font_sort` since we're manually filtering out colored
+                // outline fonts.
                 if coverage.merge(charset) {
-                    let pattern = fallback_font.strong_count();
+                    let pattern = fallback_font.upgrade();
                     Some(FallbackFont::Ref { pattern, hash })
                 } else {
                     None
@@ -450,7 +450,7 @@ impl FreeTypeRasterizer {
         for fallback_font in &mut fallback_list.list {
             if let FallbackFont::Ref { pattern, hash } = fallback_font {
                 // Don't try to build font if it doesn't have character we need.
-                if !pattern.get_charset().expect("not filtred font").has_char(glyph.character) {
+                if !pattern.get_charset().unwrap().has_char(glyph.character) {
                     continue;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Style {
         match *self {
             Style::Specific(ref s) => f.write_str(s),
             Style::Description { slant, weight } => {
-                write!(f, "slant={:?}, weight={:?}", slant, weight)
+                write!(f, "slant={slant:?}, weight={weight:?}")
             },
         }
     }
@@ -221,13 +221,13 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Error::FontNotFound(font) => write!(f, "font {:?} not found", font),
+            Error::FontNotFound(font) => write!(f, "font {font:?} not found"),
             Error::MissingGlyph(glyph) => {
                 write!(f, "glyph for character {:?} not found", glyph.character)
             },
             Error::UnknownFontKey => f.write_str("invalid font key"),
             Error::MetricsNotFound => f.write_str("metrics not found"),
-            Error::PlatformError(err) => write!(f, "{}", err),
+            Error::PlatformError(err) => write!(f, "{err}"),
         }
     }
 }


### PR DESCRIPTION
We can not render them, so exclude them from fontconfig list. This also changes the way fonts are being handled by deferring the rendering of the pattern until the requested font actually needed improving request times.